### PR TITLE
Added 'AbstractMergers.jl' to allow for different types of 'Merger's

### DIFF
--- a/src/AbstractMergers.jl
+++ b/src/AbstractMergers.jl
@@ -1,0 +1,20 @@
+module AbstractMergers
+
+import Flux: children, mapchildren
+import Base: show
+
+export AbstractMerger, inputname
+
+"""
+    AbstractMerger
+
+Abstract base type for mergers.
+
+# Interface
+
+Any subtype should support to combine a forward stream with other streams that
+can be accessed through a state dictionary via their `Splitter` name.
+"""
+abstract type AbstractMerger end
+
+end # module AbstractMergers

--- a/src/FeedbackNets.jl
+++ b/src/FeedbackNets.jl
@@ -8,12 +8,14 @@ module FeedbackNets
 using Reexport
 
 include("Splitters.jl")
+include("AbstractMergers.jl")
 include("Mergers.jl")
 include("AbstractFeedbackNets.jl")
 include("FeedbackChains.jl")
 include("FeedbackTrees.jl")
 include("ModelFactory.jl")
 @reexport using .Splitters
+@reexport using .AbstractMergers
 @reexport using .Mergers
 @reexport using .AbstractFeedbackNets
 @reexport using .FeedbackChains

--- a/src/Mergers.jl
+++ b/src/Mergers.jl
@@ -3,6 +3,8 @@ module Mergers
 import Flux: children, mapchildren
 import Base: show
 
+using ..AbstractMergers
+
 export Merger, inputname
 
 """
@@ -22,7 +24,7 @@ encounters a `Merger`, it will look up the state `s` of the `Splitter` given by 
 from the previous timestep, apply `fb` to it and combine it with the forward input `x`
 according  to `op(x, fb(s))`
 """
-struct Merger{F,O}
+struct Merger{F,O} <: AbstractMerger
     splitname::String
     fb::F
     op::O


### PR DESCRIPTION
Added a new file 'AbstractMergers.jl' in order to be able to extend the framework's 'Merger' concept to more arbitrary combinations of forward stream and 'Splitter' states.